### PR TITLE
feat: Changes to prop close-icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ npm i vue-tabs-chrome -S
 | Attributes | Description    |
 | ---------- | -------------- |
 | after      | Tab after slot |
+| close-icon | Close icon     |
 
 ## Change log
 

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -54,6 +54,14 @@
     <p>google tab has custom close icon, and cant close.</p>
     <example-custom-close></example-custom-close>
     <h2>
+      <a href="#custom-tab-buttons" name="listener">Custom tab icons</a>
+    </h2>
+    <p>
+      <a href="https://github.com/viewweiwu/vue-tabs-chrome/blob/master/examples/example/example-custom-tab.buttons.vue" target="_blank">code</a>
+    </p>
+    <p>google tab has custom tab icons</p>
+    <example-custom-tab-buttons></example-custom-tab-buttons>
+    <h2>
       <a href="#insert" name="insert">Insert to tag's after</a>
     </h2>
     <p>
@@ -87,9 +95,10 @@ import ExampleInsert from './example/example-insert'
 import ExampleCustomClose from './example/example-custom-close'
 import ExampleEvents from './example/example-events'
 import ExampleSwap from './example/example-swap'
+import ExampleCustomTabButtons from './example/example-custom-tab-buttons'
 export default {
   name: 'app',
-  components: { Example, ExampleChrome, ExampleDark, ExampleCustom, ExampleAfter, ExampleInsert, ExampleCustomClose, ExampleEvents, ExampleSwap }
+  components: { Example, ExampleChrome, ExampleDark, ExampleCustom, ExampleAfter, ExampleInsert, ExampleCustomClose, ExampleEvents, ExampleSwap, ExampleCustomTabButtons }
 }
 </script>
 

--- a/examples/example/example-custom-tab-buttons.vue
+++ b/examples/example/example-custom-tab-buttons.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="content example-custom-close">
+    <vue-tabs-chrome ref="tab" v-model="tab" :tabs="tabs" @contextmenu="handleClick" :onClose="onClose" :tab-close-width="50">
+      <template #close-icon="{tab: tabSelected, index}">
+        <div class="btn-container">
+          <a class="btn-1" @click.stop="button1(tabSelected, index)"></a>
+          <a class="btn-2" @click.stop="button2(tabSelected, index)"></a>
+        </div>
+      </template>
+    </vue-tabs-chrome>
+    <div class="btns">
+      <button @click="addTab">New Tab</button>
+      <button @click="removeTab">Remove active Tab</button>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      tab: 'google',
+      tabs: [
+        {
+          label: 'google',
+          key: 'google',
+          favicon: require('../assets/google.jpg')
+        },
+        {
+          label: 'facebook',
+          key: 'facebook',
+          favicon: require('../assets/fb.jpg')
+        }
+      ]
+    }
+  },
+  methods: {
+    addTab () {
+      let item = 'tab' + Date.now()
+      let newTabs = [
+        {
+          label: 'New Tab',
+          key: item,
+          closable: false
+        }
+      ]
+      this.$refs.tab.addTab(...newTabs)
+      this.tab = item
+    },
+
+    button1 (tabSelected, index) {
+      console.log(tabSelected, index)
+      alert('You pressed button 1! index: ' + index + 'tab: ' + JSON.stringify(tabSelected))
+    },
+    button2 (tabSelected, index) {
+      console.log(tabSelected, index)
+      alert('You pressed button 2! index: ' + index + 'tab: ' + JSON.stringify(tabSelected))
+    },
+    removeTab () {
+      this.$refs.tab.removeTab(this.tab)
+    },
+    handleClick (e, tab, i) {
+      console.log(e, tab, i)
+    },
+    onClose (tab, key, index) {
+      console.log(tab, key, index)
+      // do not update tab key
+      if (tab.class === 'go') {
+        alert('you cant close this tab')
+        return false
+      }
+      return true
+    }
+  }
+}
+</script>
+
+<style lang="less">
+
+.btn-container {
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+}
+
+.btn-1 {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: gold;
+
+  &:hover {
+    background-color: black;
+  }
+}
+
+.btn-2 {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: silver;
+
+  &:hover {
+    background-color: black;
+  }
+}
+</style>

--- a/packages/vue-tabs-chrome.vue
+++ b/packages/vue-tabs-chrome.vue
@@ -20,10 +20,10 @@
             path(d="M 0 7 A 7 7 0 0 0 7 0 L 7 7 Z")
           svg.tabs-background-after(width="7" height="7")
             path(d="M 0 0 A 7 7 0 0 0 7 7 L 0 7 Z")
-        .tabs-close(@click.stop="handleDelete(tab, i)" v-show="canShowTabClose(tab)")
-          slot(v-if="$slots['close-icon']" name="close-icon")
-          svg.tabs-close-icon(v-else width="16" height="16" stroke="#595959")
-            path(d="M 4 4 L 12 12 M 12 4 L 4 12")
+        .tabs-close(@click.stop="handleDelete(tab, i)" v-show="canShowTabClose(tab)" :style="{ width: tabCloseWidth + 'px' }")
+          slot(name="close-icon" :tab="tab" :index="i")
+            svg.tabs-close-icon(width="16" height="16" stroke="#595959")
+              path(d="M 4 4 L 12 12 M 12 4 L 4 12")
         .tabs-main(:title="tab | tabLabelText(tabLabel, renderLabel)")
           span.tabs-favicon(v-if="tab.favicon")
             render-temp(
@@ -141,6 +141,10 @@ export default {
     },
     onClose: {
       type: Function
+    },
+    tabCloseWidth: {
+      type: Number,
+      default: 16
     }
   },
   data () {


### PR DESCRIPTION
# Description

Improved slot `close-icon` to be more customizable. Now it can be used to introduce new buttons.


# Changes

- Removed v-if/v-else on slot `close-icon` and introduced fallback content.  Basically now `close-icon` slot is always used, but when it is not defined the old `x` (the svg that was on the v-else) is used
- Introduced new prop tabCloseWidth the default value is 16 (as it was in the css class)
- Updated readme for slot  `close-icon`
- Created new example for tabs with two buttons

# Tests done

- [ x ] Test default slot on other examples
- [ x ] Test old close examples 
- [ x ] Test example two buttons